### PR TITLE
fix: toast styling to properly display richColors

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,16 +29,15 @@ import UITestPageSwitch from "./components/navigation/UITestPageSwitch";
 function App() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-white to-pink-50">
-      <Toaster 
-        position="top-center" 
-        richColors 
+      <Toaster
+        position="top-center"
+        richColors
         toastOptions={{
           style: {
-            background: 'white',
-            color: '#333',
-            border: '1px solid #fce7f3',
-            borderRadius: '0.75rem',
-            boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
+            border: "1px solid #fce7f3",
+            borderRadius: "0.75rem",
+            boxShadow:
+              "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)",
           },
         }}
       />


### PR DESCRIPTION
Removed manual background and color styling from Toaster component to allow richColors prop to display proper notification colors (red for errors, etc.) while maintaining custom border and shadow styles.