### PR TITLE
Fix for #82 : 2 columns for desktop view of age verification page

### DIFF
--- a/frontend/src/pages/assessment/age-verification/page.tsx
+++ b/frontend/src/pages/assessment/age-verification/page.tsx
@@ -41,7 +41,7 @@ export default function AgeVerificationPage() {
         <Card className="w-full mb-8 shadow-md hover:shadow-lg transition-shadow duration-300">
           <CardContent className="pt-8 pb-8">
             <RadioGroup value={selectedAge || ""} onValueChange={handleAgeChange}>
-              <div className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className={`flex items-center space-x-3 border rounded-xl p-4 transition-all duration-300 ${selectedAge === "under-13" ? "border-pink-500 bg-pink-50" : "hover:bg-gray-50"}`}>
                   <RadioGroupItem value="under-13" id="under-13" className="text-pink-500" />
                   <Label htmlFor="under-13" className="flex-1 cursor-pointer">
@@ -78,7 +78,7 @@ export default function AgeVerificationPage() {
           </CardContent>
         </Card>
 
-        <div className="flex justify-between w-full mt-auto">
+        <div className="flex justify-between w-full">
           <Link to="/">
             <Button variant="outline" className="flex items-center px-6 py-6 text-lg">
               <ChevronLeft className="h-5 w-5 mr-2" />

--- a/frontend/src/pages/assessment/age-verification/page.tsx
+++ b/frontend/src/pages/assessment/age-verification/page.tsx
@@ -33,50 +33,53 @@ export default function AgeVerificationPage() {
           <div className="bg-pink-500 h-2 rounded-full w-[16%] transition-all duration-500"></div>
         </div>
 
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold mb-3">What is your age range?</h1>
-          <p className="text-gray-600">This helps us provide age-appropriate information and recommendations.</p>
-        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="text-center content-center mb-8">
+            <h1 className="text-xl font-bold mb-2">Question 1 of 6</h1>
+            <h1 className="text-3xl font-bold mb-3">What is your age range?</h1>
+            <p className="text-gray-600">This helps us provide age-appropriate information and recommendations.</p>
+          </div>
 
-        <Card className="w-full mb-8 shadow-md hover:shadow-lg transition-shadow duration-300">
-          <CardContent className="pt-8 pb-8">
-            <RadioGroup value={selectedAge || ""} onValueChange={handleAgeChange}>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <Card className="w-full mb-8 shadow-md hover:shadow-lg transition-shadow duration-300">
+            <CardContent className="pt-8 pb-8">
+              <RadioGroup value={selectedAge || ""} onValueChange={handleAgeChange}>
+              <div className="space-y-4">
                 <div className={`flex items-center space-x-3 border rounded-xl p-4 transition-all duration-300 ${selectedAge === "under-13" ? "border-pink-500 bg-pink-50" : "hover:bg-gray-50"}`}>
                   <RadioGroupItem value="under-13" id="under-13" className="text-pink-500" />
-                  <Label htmlFor="under-13" className="flex-1 cursor-pointer">
-                    <div className="font-medium text-lg">Under 13 years</div>
+                    <Label htmlFor="under-13" className="flex-1 cursor-pointer">
+                      <div className="font-medium text-lg">Under 13 years</div>
                     <p className="text-sm text-gray-500">Parental guidance recommended</p>
-                  </Label>
-                </div>
+                    </Label>
+                  </div>
 
                 <div className={`flex items-center space-x-3 border rounded-xl p-4 transition-all duration-300 ${selectedAge === "13-17" ? "border-pink-500 bg-pink-50" : "hover:bg-gray-50"}`}>
                   <RadioGroupItem value="13-17" id="13-17" className="text-pink-500" />
-                  <Label htmlFor="13-17" className="flex-1 cursor-pointer">
-                    <div className="font-medium text-lg">13-17 years</div>
+                    <Label htmlFor="13-17" className="flex-1 cursor-pointer">
+                      <div className="font-medium text-lg">13-17 years</div>
                     <p className="text-sm text-gray-500">Teen-appropriate content</p>
-                  </Label>
-                </div>
+                    </Label>
+                  </div>
 
                 <div className={`flex items-center space-x-3 border rounded-xl p-4 transition-all duration-300 ${selectedAge === "18-24" ? "border-pink-500 bg-pink-50" : "hover:bg-gray-50"}`}>
                   <RadioGroupItem value="18-24" id="18-24" className="text-pink-500" />
-                  <Label htmlFor="18-24" className="flex-1 cursor-pointer">
-                    <div className="font-medium text-lg">18-24 years</div>
+                    <Label htmlFor="18-24" className="flex-1 cursor-pointer">
+                      <div className="font-medium text-lg">18-24 years</div>
                     <p className="text-sm text-gray-500">Young adult content</p>
-                  </Label>
-                </div>
+                    </Label>
+                  </div>
 
                 <div className={`flex items-center space-x-3 border rounded-xl p-4 transition-all duration-300 ${selectedAge === "25-plus" ? "border-pink-500 bg-pink-50" : "hover:bg-gray-50"}`}>
                   <RadioGroupItem value="25-plus" id="25-plus" className="text-pink-500" />
-                  <Label htmlFor="25-plus" className="flex-1 cursor-pointer">
-                    <div className="font-medium text-lg">25+ years</div>
-                    <p className="text-sm text-gray-500">Adult content</p>
-                  </Label>
+                    <Label htmlFor="25-plus" className="flex-1 cursor-pointer">
+                      <div className="font-medium text-lg">25+ years</div>
+                      <p className="text-sm text-gray-500">Adult content</p>
+                    </Label>
+                  </div>
                 </div>
-              </div>
-            </RadioGroup>
-          </CardContent>
-        </Card>
+              </RadioGroup>
+            </CardContent>
+          </Card>
+        </div>
 
         <div className="flex justify-between w-full">
           <Link to="/">
@@ -87,8 +90,8 @@ export default function AgeVerificationPage() {
           </Link>
 
           <Link to={selectedAge ? "/assessment/cycle-length" : "#"}>
-            <Button 
-              className={`flex items-center px-6 py-6 text-lg ${selectedAge ? "bg-pink-500 hover:bg-pink-600 text-white" : "bg-gray-300 text-gray-500 cursor-not-allowed"}`} 
+            <Button
+              className={`flex items-center px-6 py-6 text-lg ${selectedAge ? "bg-pink-500 hover:bg-pink-600 text-white" : "bg-gray-300 text-gray-500 cursor-not-allowed"}`}
               disabled={!selectedAge}
             >
               Continue

--- a/frontend/src/pages/assessment/cycle-length/page.tsx
+++ b/frontend/src/pages/assessment/cycle-length/page.tsx
@@ -27,7 +27,7 @@ export default function CycleLengthPage() {
         <UserIcon />
       </header>
 
-      <main className="flex-1 flex flex-col p-6 max-w-md mx-auto w-full">
+      <main className="flex-1 flex flex-col p-6 max-w-2xl mx-auto w-full">
         <div className="flex items-center justify-between mb-4">
           <div className="text-sm text-gray-500">33% Complete</div>
         </div>
@@ -36,71 +36,75 @@ export default function CycleLengthPage() {
           <div className="bg-pink-500 h-2 rounded-full w-[33%]"></div>
         </div>
 
-        <h1 className="text-xl font-bold mb-2">Question 2 of 6</h1>
-        <h2 className="text-lg font-semibold mb-1">How long is your menstrual cycle?</h2>
-        <p className="text-sm text-gray-500 mb-6">
-          Count from the first day of one period to the first day of the next period
-        </p>
-
-        <RadioGroup value={selectedLength || ""} onValueChange={handleLengthChange} className="mb-6">
-          <div className="space-y-3">
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="21-25" id="21-25" />
-              <Label htmlFor="21-25" className="flex-1 cursor-pointer">
-                <div className="font-medium">21-25 days</div>
-                <p className="text-sm text-gray-500">Shorter than average</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="26-30" id="26-30" />
-              <Label htmlFor="26-30" className="flex-1 cursor-pointer">
-                <div className="font-medium">26-30 days</div>
-                <p className="text-sm text-gray-500">Average length</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="31-35" id="31-35" />
-              <Label htmlFor="31-35" className="flex-1 cursor-pointer">
-                <div className="font-medium">31-35 days</div>
-                <p className="text-sm text-gray-500">Longer than average</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="36-40" id="36-40" />
-              <Label htmlFor="36-40" className="flex-1 cursor-pointer">
-                <div className="font-medium">36-40 days</div>
-                <p className="text-sm text-gray-500">Extended cycle</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="irregular" id="irregular" />
-              <Label htmlFor="irregular" className="flex-1 cursor-pointer">
-                <div className="font-medium">Irregular</div>
-                <p className="text-sm text-gray-500">Varies by more than 7 days</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="not-sure" id="not-sure" />
-              <Label htmlFor="not-sure" className="flex-1 cursor-pointer">
-                <div className="font-medium">I'm not sure</div>
-                <p className="text-sm text-gray-500">Need help tracking</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="other" id="other" />
-              <Label htmlFor="other" className="flex-1 cursor-pointer">
-                <div className="font-medium">Other</div>
-                <p className="text-sm text-gray-500">Specify your own cycle length</p>
-              </Label>
-            </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="text-center content-center mb-8">
+            <h1 className="text-xl font-bold mb-2">Question 2 of 6</h1>
+            <h1 className="text-3xl font-bold mb-3">How long is your menstrual cycle?</h1>
+            <p className="text-gray-600">
+              Count from the first day of one period to the first day of the next period
+            </p>
           </div>
-        </RadioGroup>
+
+          <RadioGroup value={selectedLength || ""} onValueChange={handleLengthChange} className="mb-6">
+            <div className="space-y-3">
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="21-25" id="21-25" />
+                <Label htmlFor="21-25" className="flex-1 cursor-pointer">
+                  <div className="font-medium">21-25 days</div>
+                  <p className="text-sm text-gray-500">Shorter than average</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="26-30" id="26-30" />
+                <Label htmlFor="26-30" className="flex-1 cursor-pointer">
+                  <div className="font-medium">26-30 days</div>
+                  <p className="text-sm text-gray-500">Average length</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="31-35" id="31-35" />
+                <Label htmlFor="31-35" className="flex-1 cursor-pointer">
+                  <div className="font-medium">31-35 days</div>
+                  <p className="text-sm text-gray-500">Longer than average</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="36-40" id="36-40" />
+                <Label htmlFor="36-40" className="flex-1 cursor-pointer">
+                  <div className="font-medium">36-40 days</div>
+                  <p className="text-sm text-gray-500">Extended cycle</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="irregular" id="irregular" />
+                <Label htmlFor="irregular" className="flex-1 cursor-pointer">
+                  <div className="font-medium">Irregular</div>
+                  <p className="text-sm text-gray-500">Varies by more than 7 days</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="not-sure" id="not-sure" />
+                <Label htmlFor="not-sure" className="flex-1 cursor-pointer">
+                  <div className="font-medium">I'm not sure</div>
+                  <p className="text-sm text-gray-500">Need help tracking</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="other" id="other" />
+                <Label htmlFor="other" className="flex-1 cursor-pointer">
+                  <div className="font-medium">Other</div>
+                  <p className="text-sm text-gray-500">Specify your own cycle length</p>
+                </Label>
+              </div>
+            </div>
+          </RadioGroup>
+        </div>
 
         <Card className="w-full mb-8 bg-pink-50 border-pink-100">
           <CardContent className="pt-6">

--- a/frontend/src/pages/assessment/flow/page.tsx
+++ b/frontend/src/pages/assessment/flow/page.tsx
@@ -27,7 +27,7 @@ export default function FlowPage() {
         <UserIcon />
       </header>
 
-      <main className="flex-1 flex flex-col p-6 max-w-md mx-auto w-full">
+      <main className="flex-1 flex flex-col p-6 max-w-2xl mx-auto w-full">
         <div className="flex items-center justify-between mb-4">
           <div className="text-sm text-gray-500">67% Complete</div>
         </div>
@@ -36,61 +36,66 @@ export default function FlowPage() {
           <div className="bg-pink-500 h-2 rounded-full w-[67%]"></div>
         </div>
 
-        <h1 className="text-xl font-bold mb-2">Question 4 of 6</h1>
-        <h2 className="text-lg font-semibold mb-1">How would you describe your menstrual flow?</h2>
-        <p className="text-sm text-gray-500 mb-6">Select the option that best describes your typical flow heaviness</p>
-
-        <RadioGroup value={selectedFlow || ""} onValueChange={handleFlowChange} className="mb-6">
-          <div className="space-y-3">
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="light" id="light" />
-              <Label htmlFor="light" className="flex-1 cursor-pointer">
-                <div className="font-medium">Light</div>
-                <p className="text-sm text-gray-500">Minimal bleeding, may only need panty liners</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="moderate" id="moderate" />
-              <Label htmlFor="moderate" className="flex-1 cursor-pointer">
-                <div className="font-medium">Moderate</div>
-                <p className="text-sm text-gray-500">Regular bleeding, requires normal protection</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="heavy" id="heavy" />
-              <Label htmlFor="heavy" className="flex-1 cursor-pointer">
-                <div className="font-medium">Heavy</div>
-                <p className="text-sm text-gray-500">Substantial bleeding, requires frequent changes</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="very-heavy" id="very-heavy" />
-              <Label htmlFor="very-heavy" className="flex-1 cursor-pointer">
-                <div className="font-medium">Very Heavy</div>
-                <p className="text-sm text-gray-500">Excessive bleeding, may soak through protection</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="varies" id="varies" />
-              <Label htmlFor="varies" className="flex-1 cursor-pointer">
-                <div className="font-medium">It varies</div>
-                <p className="text-sm text-gray-500">Changes throughout your period or between cycles</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="not-sure" id="not-sure" />
-              <Label htmlFor="not-sure" className="flex-1 cursor-pointer">
-                <div className="font-medium">I'm not sure</div>
-                <p className="text-sm text-gray-500">Need help determining flow heaviness</p>
-              </Label>
-            </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="text-center content-center mb-8">
+            <h1 className="text-xl font-bold mb-2">Question 4 of 6</h1>
+            <h1 className="text-3xl font-bold mb-3">How would you describe your menstrual flow?</h1>
+            <p className="text-gray-600">
+              Select the option that best describes your typical flow heaviness</p>
           </div>
-        </RadioGroup>
+          
+          <RadioGroup value={selectedFlow || ""} onValueChange={handleFlowChange} className="mb-6">
+            <div className="space-y-3">
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="light" id="light" />
+                <Label htmlFor="light" className="flex-1 cursor-pointer">
+                  <div className="font-medium">Light</div>
+                  <p className="text-sm text-gray-500">Minimal bleeding, may only need panty liners</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="moderate" id="moderate" />
+                <Label htmlFor="moderate" className="flex-1 cursor-pointer">
+                  <div className="font-medium">Moderate</div>
+                  <p className="text-sm text-gray-500">Regular bleeding, requires normal protection</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="heavy" id="heavy" />
+                <Label htmlFor="heavy" className="flex-1 cursor-pointer">
+                  <div className="font-medium">Heavy</div>
+                  <p className="text-sm text-gray-500">Substantial bleeding, requires frequent changes</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="very-heavy" id="very-heavy" />
+                <Label htmlFor="very-heavy" className="flex-1 cursor-pointer">
+                  <div className="font-medium">Very Heavy</div>
+                  <p className="text-sm text-gray-500">Excessive bleeding, may soak through protection</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="varies" id="varies" />
+                <Label htmlFor="varies" className="flex-1 cursor-pointer">
+                  <div className="font-medium">It varies</div>
+                  <p className="text-sm text-gray-500">Changes throughout your period or between cycles</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="not-sure" id="not-sure" />
+                <Label htmlFor="not-sure" className="flex-1 cursor-pointer">
+                  <div className="font-medium">I'm not sure</div>
+                  <p className="text-sm text-gray-500">Need help determining flow heaviness</p>
+                </Label>
+              </div>
+            </div>
+          </RadioGroup>
+        </div>
 
         <Card className="w-full mb-8 bg-pink-50 border-pink-100">
           <CardContent className="pt-6">
@@ -115,7 +120,7 @@ export default function FlowPage() {
           Your data is private and secure. Dottie does not store your personal health information.
         </p>
 
-        <div className="flex justify-between w-full mt-auto">
+        <div className="flex justify-between w-full">
           <Link to="/assessment/period-duration">
             <Button variant="outline" className="flex items-center">
               <ChevronLeft className="h-4 w-4 mr-2" />

--- a/frontend/src/pages/assessment/pain/page.tsx
+++ b/frontend/src/pages/assessment/pain/page.tsx
@@ -27,7 +27,7 @@ export default function PainPage() {
         <UserIcon />
       </header>
 
-      <main className="flex-1 flex flex-col p-6 max-w-md mx-auto w-full">
+      <main className="flex-1 flex flex-col p-6 max-w-2xl mx-auto w-full">
         <div className="flex items-center justify-between mb-4">
           <div className="text-sm text-gray-500">83% Complete</div>
         </div>
@@ -36,64 +36,68 @@ export default function PainPage() {
           <div className="bg-pink-500 h-2 rounded-full w-[83%]"></div>
         </div>
 
-        <h1 className="text-xl font-bold mb-2">Question 5 of 6</h1>
-        <h2 className="text-lg font-semibold mb-1">How would you rate your menstrual pain?</h2>
-        <p className="text-sm text-gray-500 mb-6">
-          Select the option that best describes your typical pain level during your period
-        </p>
-
-        <RadioGroup value={selectedPain || ""} onValueChange={handlePainChange} className="mb-6">
-          <div className="space-y-3">
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="no-pain" id="no-pain" />
-              <Label htmlFor="no-pain" className="flex-1 cursor-pointer">
-                <div className="font-medium">No Pain</div>
-                <p className="text-sm text-gray-500">I don't experience any discomfort during my period</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="mild" id="mild" />
-              <Label htmlFor="mild" className="flex-1 cursor-pointer">
-                <div className="font-medium">Mild</div>
-                <p className="text-sm text-gray-500">Noticeable but doesn't interfere with daily activities</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="moderate" id="moderate" />
-              <Label htmlFor="moderate" className="flex-1 cursor-pointer">
-                <div className="font-medium">Moderate</div>
-                <p className="text-sm text-gray-500">Uncomfortable and may require pain relief</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="severe" id="severe" />
-              <Label htmlFor="severe" className="flex-1 cursor-pointer">
-                <div className="font-medium">Severe</div>
-                <p className="text-sm text-gray-500">Significant pain that limits normal activities</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="debilitating" id="debilitating" />
-              <Label htmlFor="debilitating" className="flex-1 cursor-pointer">
-                <div className="font-medium">Debilitating</div>
-                <p className="text-sm text-gray-500">Extreme pain that prevents normal activities</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="varies" id="varies" />
-              <Label htmlFor="varies" className="flex-1 cursor-pointer">
-                <div className="font-medium">It varies</div>
-                <p className="text-sm text-gray-500">Pain level changes throughout your period or between cycles</p>
-              </Label>
-            </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="text-center content-center mb-8">
+            <h1 className="text-xl font-bold mb-2">Question 5 of 6</h1>
+            <h1 className="text-3xl font-bold mb-3">How would you rate your menstrual pain?</h1>
+            <p className="text-gray-600">
+              Select the option that best describes your typical pain level during your period
+            </p>
           </div>
-        </RadioGroup>
 
+          <RadioGroup value={selectedPain || ""} onValueChange={handlePainChange} className="mb-6">
+            <div className="space-y-3">
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="no-pain" id="no-pain" />
+                <Label htmlFor="no-pain" className="flex-1 cursor-pointer">
+                  <div className="font-medium">No Pain</div>
+                  <p className="text-sm text-gray-500">I don't experience any discomfort during my period</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="mild" id="mild" />
+                <Label htmlFor="mild" className="flex-1 cursor-pointer">
+                  <div className="font-medium">Mild</div>
+                  <p className="text-sm text-gray-500">Noticeable but doesn't interfere with daily activities</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="moderate" id="moderate" />
+                <Label htmlFor="moderate" className="flex-1 cursor-pointer">
+                  <div className="font-medium">Moderate</div>
+                  <p className="text-sm text-gray-500">Uncomfortable and may require pain relief</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="severe" id="severe" />
+                <Label htmlFor="severe" className="flex-1 cursor-pointer">
+                  <div className="font-medium">Severe</div>
+                  <p className="text-sm text-gray-500">Significant pain that limits normal activities</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="debilitating" id="debilitating" />
+                <Label htmlFor="debilitating" className="flex-1 cursor-pointer">
+                  <div className="font-medium">Debilitating</div>
+                  <p className="text-sm text-gray-500">Extreme pain that prevents normal activities</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="varies" id="varies" />
+                <Label htmlFor="varies" className="flex-1 cursor-pointer">
+                  <div className="font-medium">It varies</div>
+                  <p className="text-sm text-gray-500">Pain level changes throughout your period or between cycles</p>
+                </Label>
+              </div>
+            </div>
+          </RadioGroup>
+        </div>
+        
         <Card className="w-full mb-8 bg-pink-50 border-pink-100">
           <CardContent className="pt-6">
             <div className="flex gap-2">
@@ -117,7 +121,7 @@ export default function PainPage() {
           Your data is private and secure. Dottie does not store your personal health information.
         </p>
 
-        <div className="flex justify-between w-full mt-auto">
+        <div className="flex justify-between w-full">
           <Link to="/assessment/flow">
             <Button variant="outline" className="flex items-center">
               <ChevronLeft className="h-4 w-4 mr-2" />

--- a/frontend/src/pages/assessment/period-duration/page.tsx
+++ b/frontend/src/pages/assessment/period-duration/page.tsx
@@ -27,7 +27,7 @@ export default function PeriodDurationPage() {
         <UserIcon />
       </header>
 
-      <main className="flex-1 flex flex-col p-6 max-w-md mx-auto w-full">
+      <main className="flex-1 flex flex-col p-6 max-w-2xl mx-auto w-full">
         <div className="flex items-center justify-between mb-4">
           <div className="text-sm text-gray-500">50% Complete</div>
         </div>
@@ -36,69 +36,74 @@ export default function PeriodDurationPage() {
           <div className="bg-pink-500 h-2 rounded-full w-[50%]"></div>
         </div>
 
-        <h1 className="text-xl font-bold mb-2">Question 3 of 6</h1>
-        <h2 className="text-lg font-semibold mb-1">How many days does your period typically last?</h2>
-        <p className="text-sm text-gray-500 mb-6">Count the days from when bleeding starts until it completely stops</p>
-
-        <RadioGroup value={selectedDuration || ""} onValueChange={handleDurationChange} className="mb-6">
-          <div className="space-y-3">
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="1-3" id="1-3" />
-              <Label htmlFor="1-3" className="flex-1 cursor-pointer">
-                <div className="font-medium">1-3 days</div>
-                <p className="text-sm text-gray-500">Shorter duration</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="4-5" id="4-5" />
-              <Label htmlFor="4-5" className="flex-1 cursor-pointer">
-                <div className="font-medium">4-5 days</div>
-                <p className="text-sm text-gray-500">Average duration</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="6-7" id="6-7" />
-              <Label htmlFor="6-7" className="flex-1 cursor-pointer">
-                <div className="font-medium">6-7 days</div>
-                <p className="text-sm text-gray-500">Longer duration</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="8-plus" id="8-plus" />
-              <Label htmlFor="8-plus" className="flex-1 cursor-pointer">
-                <div className="font-medium">8+ days</div>
-                <p className="text-sm text-gray-500">Extended duration</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="varies" id="varies" />
-              <Label htmlFor="varies" className="flex-1 cursor-pointer">
-                <div className="font-medium">It varies</div>
-                <p className="text-sm text-gray-500">Changes from cycle to cycle</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="not-sure" id="not-sure" />
-              <Label htmlFor="not-sure" className="flex-1 cursor-pointer">
-                <div className="font-medium">I'm not sure</div>
-                <p className="text-sm text-gray-500">Need help tracking</p>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
-              <RadioGroupItem value="other" id="other" />
-              <Label htmlFor="other" className="flex-1 cursor-pointer">
-                <div className="font-medium">Other</div>
-                <p className="text-sm text-gray-500">Specify your own period duration</p>
-              </Label>
-            </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="text-center content-center mb-8">
+            <h1 className="text-xl font-bold mb-2">Question 3 of 6</h1>
+            <h1 className="text-3xl font-bold mb-3">How many days does your period typically last?</h1>
+            <p className="text-gray-600">
+              Count the days from when bleeding starts until it completely stops</p>
           </div>
-        </RadioGroup>
+
+          <RadioGroup value={selectedDuration || ""} onValueChange={handleDurationChange} className="mb-6">
+            <div className="space-y-3">
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="1-3" id="1-3" />
+                <Label htmlFor="1-3" className="flex-1 cursor-pointer">
+                  <div className="font-medium">1-3 days</div>
+                  <p className="text-sm text-gray-500">Shorter duration</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="4-5" id="4-5" />
+                <Label htmlFor="4-5" className="flex-1 cursor-pointer">
+                  <div className="font-medium">4-5 days</div>
+                  <p className="text-sm text-gray-500">Average duration</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="6-7" id="6-7" />
+                <Label htmlFor="6-7" className="flex-1 cursor-pointer">
+                  <div className="font-medium">6-7 days</div>
+                  <p className="text-sm text-gray-500">Longer duration</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="8-plus" id="8-plus" />
+                <Label htmlFor="8-plus" className="flex-1 cursor-pointer">
+                  <div className="font-medium">8+ days</div>
+                  <p className="text-sm text-gray-500">Extended duration</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="varies" id="varies" />
+                <Label htmlFor="varies" className="flex-1 cursor-pointer">
+                  <div className="font-medium">It varies</div>
+                  <p className="text-sm text-gray-500">Changes from cycle to cycle</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="not-sure" id="not-sure" />
+                <Label htmlFor="not-sure" className="flex-1 cursor-pointer">
+                  <div className="font-medium">I'm not sure</div>
+                  <p className="text-sm text-gray-500">Need help tracking</p>
+                </Label>
+              </div>
+
+              <div className="flex items-center space-x-2 border rounded-lg p-3 hover:bg-gray-50">
+                <RadioGroupItem value="other" id="other" />
+                <Label htmlFor="other" className="flex-1 cursor-pointer">
+                  <div className="font-medium">Other</div>
+                  <p className="text-sm text-gray-500">Specify your own period duration</p>
+                </Label>
+              </div>
+            </div>
+          </RadioGroup>
+        </div>
 
         <Card className="w-full mb-8 bg-pink-50 border-pink-100">
           <CardContent className="pt-6">
@@ -122,7 +127,7 @@ export default function PeriodDurationPage() {
           Your data is private and secure. Dottie does not store your personal health information.
         </p>
 
-        <div className="flex justify-between w-full mt-auto">
+        <div className="flex justify-between w-full">
           <Link to="/assessment/cycle-length">
             <Button variant="outline" className="flex items-center">
               <ChevronLeft className="h-4 w-4 mr-2" />


### PR DESCRIPTION
Before: Desktop and mobile view both had 1 column for all the age options

After: 2 columns for desktop view and 1 column for mobile view

![image](https://github.com/user-attachments/assets/03fc034e-a05d-4830-a711-28e14d1206b2)
