### PR TITLE
Configurable backend port with .env and macOS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ This architecture allows developers to work locally without needing to set up a 
 - **Authentication**: (Coming soon) JWT-based authentication
 - **Middleware**: Express middleware for request processing
 
+### Backend Port Configuration & macOS Compatibility
+
+By default, the backend runs on:
+
+- **Port 5000** on Windows/Linux
+- **Port 5001** on macOS (to avoid conflict with AirPlay)
+
+You can override this by creating a `.env` file in `/backend`:
+
+```env
+PORT=5050
+
 ### Getting Started
 
 #### Backend Setup

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ You can override this by creating a `.env` file in `/backend`:
 
 ```env
 PORT=5050
+```
 
 ### Getting Started
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -37,7 +37,10 @@ if (isProduction && isVercel) {
 
 // Create Express app
 const app = express();
-const PORT = process.env.PORT || 5000;
+const isMac = process.platform === 'darwin';
+const PORT = process.env.PORT || (isMac ? 5001 : 5000);
+
+
 
 // Determine environment
 const isDevelopment = process.env.NODE_ENV !== 'production';


### PR DESCRIPTION
- Port is now configurable via .env (PORT=...)
- Defaults to port 5001 on macOS to avoid AirPlay conflicts
- Updated README.md with new setup instructions