### PR TITLE
[FIX] Sign-out toast message appears 3 times

### DIFF
--- a/frontend/src/pages/auth/signout.tsx
+++ b/frontend/src/pages/auth/signout.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { useAuth } from '@/src/context/AuthContext';
@@ -6,9 +6,12 @@ import { useAuth } from '@/src/context/AuthContext';
 export default function SignOut() {
   const navigate = useNavigate();
   const { logout } = useAuth();
+  const hasRun = useRef(false);
 
   useEffect(() => {
     const performSignOut = async () => {
+      if (hasRun.current) return;
+      hasRun.current = true;
       try {
         // Call the sign-out endpoint
         await logout();


### PR DESCRIPTION
Resolves #152 

Since useEffect is running multiple times and we're calling performLogout() inside it, we use useRef to remember if we've already run it once.

https://github.com/user-attachments/assets/4f5e8b55-ba83-4d3f-9001-5d71f2900b8a





