### PR TITLE
Fix: Update API port detection to use browser's userAgent for Mac detection

### DIFF
--- a/frontend/src/api/core/apiClient.ts
+++ b/frontend/src/api/core/apiClient.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
-import { getAuthToken, setAuthToken, setRefreshToken, TOKEN_KEYS } from './tokenManager';
+import axios from "axios";
+import { getAuthToken, setAuthToken, setRefreshToken } from "./tokenManager";
 
 /**
  * Axios instance for making API requests
@@ -11,28 +11,32 @@ const getBaseUrl = () => {
   if (import.meta.env.VITE_API_BASE_URL) {
     return import.meta.env.VITE_API_BASE_URL;
   }
-  
+
   // Second priority: Check for manually configured API URL in localStorage
-  const savedApiUrl = localStorage.getItem('api_base_url');
+  const savedApiUrl = localStorage.getItem("api_base_url");
   if (savedApiUrl) {
     return savedApiUrl;
   }
 
-  const isMac = process.platform === 'darwin';
-  const API_PORT = process.env.API_PORT ?? (isMac ? 5001 : 5000); 
-  
+  const isMac = window.navigator.userAgent.includes("Mac");
+  const API_PORT = isMac ? 5001 : 5000;
+  const hostNameUrl = `http://${window.location.hostname}:${API_PORT}`;
+
   // Default fallback for local development
-  if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
-    return `http://${window.location.hostname}:${API_PORT}`;
+  if (
+    window.location.hostname === "localhost" ||
+    window.location.hostname === "127.0.0.1"
+  ) {
+    return hostNameUrl;
   }
-  
+
   // Production fallback: assume API is at the same origin
   return window.location.origin;
 };
 
 // Expose a function to update the API URL at runtime
 export const setApiBaseUrl = (url: string) => {
-  localStorage.setItem('api_base_url', url);
+  localStorage.setItem("api_base_url", url);
   apiClient.defaults.baseURL = url;
   console.log(`[API Client] Base URL updated to: ${url}`);
   return url;
@@ -41,7 +45,7 @@ export const setApiBaseUrl = (url: string) => {
 const apiClient = axios.create({
   baseURL: getBaseUrl(),
   headers: {
-    'Content-Type': 'application/json',
+    "Content-Type": "application/json",
   },
 });
 
@@ -49,13 +53,15 @@ const apiClient = axios.create({
 try {
   const token = getAuthToken();
   if (token) {
-    apiClient.defaults.headers.common['Authorization'] = `Bearer ${token}`;
-    console.log('[API Client] Initialized with token from localStorage');
+    apiClient.defaults.headers.common["Authorization"] = `Bearer ${token}`;
+    console.log("[API Client] Initialized with token from localStorage");
   } else {
-    console.log('[API Client] No token found in localStorage during initialization');
+    console.log(
+      "[API Client] No token found in localStorage during initialization"
+    );
   }
 } catch (error) {
-  console.error('[API Client] Error accessing localStorage:', error);
+  console.error("[API Client] Error accessing localStorage:", error);
 }
 
 // Add a request interceptor to always try to include the latest token
@@ -64,12 +70,12 @@ apiClient.interceptors.request.use(
     try {
       // Get token using our token manager
       const token = getAuthToken();
-      
+
       if (token) {
         config.headers.Authorization = `Bearer ${token}`;
       }
     } catch (error) {
-      console.error('[API Client] Error in request interceptor:', error);
+      console.error("[API Client] Error in request interceptor:", error);
     }
     return config;
   },
@@ -86,28 +92,30 @@ apiClient.interceptors.response.use(
     if (error.response) {
       // Server responded with an error status
       console.error(`API Error: ${error.response.status}`, error.response.data);
-      
+
       // Handle 401 Unauthorized - redirect to login
       if (error.response.status === 401) {
         // Remove token and redirect to login
-        localStorage.removeItem('authToken');
+        localStorage.removeItem("authToken");
         // Redirect logic would go here for a real app
       }
     } else if (error.request) {
       // Request was made but no response received (network error)
-      console.error('Network Error:', error.request);
+      console.error("Network Error:", error.request);
     } else {
       // Something else went wrong
-      console.error('Error:', error.message);
+      console.error("Error:", error.message);
     }
-    
+
     return Promise.reject(error);
   }
 );
 
 // Helper functions to check response status
-export const isSuccess = (status: number): boolean => status >= 200 && status < 300;
-export const isClientError = (status: number): boolean => status >= 400 && status < 500;
+export const isSuccess = (status: number): boolean =>
+  status >= 200 && status < 300;
+export const isClientError = (status: number): boolean =>
+  status >= 400 && status < 500;
 export const isServerError = (status: number): boolean => status >= 500;
 
-export { apiClient, setAuthToken, setRefreshToken }; 
+export { apiClient, setAuthToken, setRefreshToken };


### PR DESCRIPTION
- Changed API client to dynamically select port 5001 for Mac users and 5000 for others
- Uses window.navigator.userAgent to detect Mac OS
- Mirrors backend logic where macOS uses port 5001 by default
- Resolves CORS issues when frontend attempts to connect to wrong port
- fixing the issue for;
1. #194 
2. #180 

### Before (using process.domain)
<img width="1458" alt="Screenshot 2025-04-18 at 4 29 56 PM" src="https://github.com/user-attachments/assets/f6b8a34c-084f-4a3a-b9f5-5fba5f185ca4" />

### After (utilise window.navigator)
<img width="1453" alt="Screenshot 2025-04-18 at 4 32 45 PM" src="https://github.com/user-attachments/assets/2de5740d-f0ef-49b5-b7b0-8403f886e2ee" />
