### PR TITLE
Frontend: Change window's alert to Sonner toast for account deletion

### DIFF
--- a/frontend/src/pages/user/account-form.tsx
+++ b/frontend/src/pages/user/account-form.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
-import { toast } from 'sonner';
-import { userApi } from '@/src/api/user';
-import { User } from '@/src/api/auth/types';
-import { useNavigate } from 'react-router-dom';
-import { useAuth } from '@/src/context/AuthContext';
+import { useState } from "react";
+import { toast } from "sonner";
+import { userApi } from "@/src/api/user";
+import { User } from "@/src/api/auth/types";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "@/src/context/AuthContext";
 
 interface AccountFormProps {
   user: User;
@@ -11,8 +11,8 @@ interface AccountFormProps {
 
 export default function AccountForm({ user }: AccountFormProps) {
   const [formData, setFormData] = useState({
-    name: user.name || '',
-    email: user.email || '',
+    name: user.name || "",
+    email: user.email || "",
   });
   const [isLoading, setIsLoading] = useState(false);
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
@@ -21,7 +21,7 @@ export default function AccountForm({ user }: AccountFormProps) {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
-    setFormData(prev => ({ ...prev, [name]: value }));
+    setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -30,32 +30,55 @@ export default function AccountForm({ user }: AccountFormProps) {
 
     try {
       await userApi.update(formData);
-      toast.success('Account updated successfully');
+      toast.success("Account updated successfully");
     } catch (error) {
-      console.error('Error updating account:', error);
-      toast.error('Failed to update account');
+      console.error("Error updating account:", error);
+      toast.error("Failed to update account");
     } finally {
       setIsLoading(false);
     }
   };
 
   const handleDeleteAccount = async () => {
-    if (!window.confirm('Are you sure you want to delete your account? This action cannot be undone.')) {
-      return;
-    }
-
-    setIsLoading(true);
-    try {
-      await userApi.delete(user.id);
-      toast.success('Account deleted successfully');
-      await logout();
-      navigate('/');
-    } catch (error) {
-      console.error('Error deleting account:', error);
-      toast.error('Failed to delete account');
-    } finally {
-      setIsLoading(false);
-    }
+    toast.custom((t) => (
+      <div className="bg-white p-4 rounded-lg shadow-lg border border-red-200 w-full max-w-md">
+        <h3 className="font-medium text-lg text-red-800">
+          Confirm Account Deletion
+        </h3>
+        <p className="mt-2 text-gray-700">
+          Are you sure you want to delete your account? This action cannot be
+          undone.
+        </p>
+        <div className="mt-4 flex justify-end space-x-2">
+          <button
+            onClick={() => toast.dismiss(t)}
+            className="px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-md"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={async () => {
+              toast.dismiss(t);
+              setIsLoading(true);
+              try {
+                await userApi.delete(user.id);
+                toast.success("Account deleted successfully");
+                await logout();
+                navigate("/");
+              } catch (error) {
+                console.error("Error deleting account:", error);
+                toast.error("Failed to delete account");
+              } finally {
+                setIsLoading(false);
+              }
+            }}
+            className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-md"
+          >
+            Delete Account
+          </button>
+        </div>
+      </div>
+    ));
   };
 
   return (
@@ -94,7 +117,7 @@ export default function AccountForm({ user }: AccountFormProps) {
           disabled={isLoading}
           className="w-full py-2 px-4 bg-pink-600 hover:bg-pink-700 text-white font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-pink-500 focus:ring-offset-2 disabled:opacity-50"
         >
-          {isLoading ? 'Updating...' : 'Update Account'}
+          {isLoading ? "Updating..." : "Update Account"}
         </button>
       </form>
 
@@ -103,17 +126,18 @@ export default function AccountForm({ user }: AccountFormProps) {
         <div className="bg-red-50 p-4 rounded-md border border-red-200">
           <h3 className="text-sm font-medium text-red-800">Delete Account</h3>
           <p className="mt-1 text-sm text-red-700">
-            Once you delete your account, there is no going back. Please be certain.
+            Once you delete your account, there is no going back. Please be
+            certain.
           </p>
           <button
             onClick={handleDeleteAccount}
             disabled={isLoading}
             className="mt-4 px-4 py-2 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50"
           >
-            {isLoading ? 'Deleting...' : 'Delete Account'}
+            {isLoading ? "Deleting..." : "Delete Account"}
           </button>
         </div>
       </div>
     </div>
   );
-} 
+}


### PR DESCRIPTION
### Changes:

- ✨ Implemented a custom Sonner toast confirmation dialog for account deletion
- 🗑️ Removed the native window.confirm dialog in favor of a styled alternative
- 🎨 Designed the confirmation dialog to match our application's aesthetic
- 🔄 Preserved all existing functionality 

### Screenshot:
![image](https://github.com/user-attachments/assets/14e5a199-a328-4a05-bcad-6f91149d5b69)


**Resolves:** #197 