### PR TITLE
Styling (landing page): "Menstrual Health" fades from black to pink after 3 seconds

### DIFF
--- a/frontend/src/pages/landing-page/page.tsx
+++ b/frontend/src/pages/landing-page/page.tsx
@@ -28,7 +28,14 @@ export default function LandingPage(): JSX.Element {
               >
                 <motion.h1 className="text-5xl md:text-6xl font-bold text-gray-900 leading-tight">
                   Your Personal
-                  <span className="text-pink-600"> Menstrual Health </span>
+                  <motion.span
+                    initial={{ color: "#111827" }}
+                    animate={{ color: "#db2777" }}
+                    transition={{ duration: 3, ease: "easeInOut" }}
+                  >
+                    {" "}
+                    Menstrual Health{" "}
+                  </motion.span>
                   Companion
                 </motion.h1>
                 <p className="text-xl md:text-2xl text-gray-600">
@@ -135,7 +142,11 @@ export default function LandingPage(): JSX.Element {
           <section className="py-20 px-6 bg-gradient-to-b from-pink-50 to-white">
             <motion.div
               className="max-w-4xl mx-auto text-center"
-              initial={{ opacity: 0, scale: 0.5, transform: "translateY(150px)" }}
+              initial={{
+                opacity: 0,
+                scale: 0.5,
+                transform: "translateY(150px)",
+              }}
               whileInView={{
                 opacity: 1,
                 scale: 1,


### PR DESCRIPTION
**What's Changed:**
- Added smooth color transition animation to the "Menstrual Health" text
- Text now fades from`text-gray-900` to `text-pink-600` over 3 seconds
- Uses Framer Motion

# Checklist

- [x] pulled `main` branch to ensure latest version and no merge conflicts
- [x] ran `cd frontend; npm run build` and confirm no type errors
- Fixes: #254 