### PR TITLE
Add tooltips and “View More” functionality for long text in symptoms card on Assessment Results page

### DIFF
--- a/frontend/src/pages/assessment/results/page.tsx
+++ b/frontend/src/pages/assessment/results/page.tsx
@@ -555,7 +555,12 @@ export default function ResultsPage() {
                 </div>
                 <div className="flex-1 overflow-x-auto">
                   <h3 className="mb-2 text-lg font-medium">Symptoms</h3>
-                  <p id="symptoms-content" title={symptoms.length > 0 ? symptoms.join(', ') : 'None reported'} aria-label={symptoms.length > 0 ? symptoms.join(', ') : 'None reported'} ref={ref} tabIndex={0} className={`whitespace-normal break-words text-gray-600 ${expandableSymptoms ? '' : 'line-clamp-2'} whitespace-pre-line`}>
+                  <p 
+                  id="symptoms-content" 
+                  title={symptoms.length > 0 ? symptoms.join(', ') : 'None reported'} 
+                  aria-label={symptoms.length > 0 ? symptoms.join(', ') : 'None reported'} 
+                  ref={ref} 
+                  className={`whitespace-normal break-words text-gray-600 ${expandableSymptoms ? '' : 'line-clamp-2'} whitespace-pre-line`}>
                     {symptoms.length > 0 ? symptoms.join(', ') : 'None reported'}
                   </p>
 

--- a/frontend/src/pages/assessment/results/page.tsx
+++ b/frontend/src/pages/assessment/results/page.tsx
@@ -555,7 +555,7 @@ export default function ResultsPage() {
                 </div>
                 <div className="flex-1 overflow-x-auto">
                   <h3 className="mb-2 text-lg font-medium">Symptoms</h3>
-                  <p title={symptoms.length > 0 ? symptoms.join(', ') : 'None reported'} ref={ref} className={`whitespace-normal break-words text-gray-600 ${expandableSymptoms ? '' : 'line-clamp-2'} whitespace-pre-line`}>
+                  <p id="symptoms-content" title={symptoms.length > 0 ? symptoms.join(', ') : 'None reported'} aria-label={symptoms.length > 0 ? symptoms.join(', ') : 'None reported'} ref={ref} tabIndex={0} className={`whitespace-normal break-words text-gray-600 ${expandableSymptoms ? '' : 'line-clamp-2'} whitespace-pre-line`}>
                     {symptoms.length > 0 ? symptoms.join(', ') : 'None reported'}
                   </p>
 
@@ -563,7 +563,7 @@ export default function ResultsPage() {
                     <button
                     onClick={() => setExpandableSymptoms((prev) => !prev)}
                     className="text-sm text-pink-600 hover:text-pink-700"
-                    aria-expanded={expandableSymptoms}   
+                    aria-expanded={expandableSymptoms}
                     aria-controls="symptoms-content"
                   >
                     {expandableSymptoms ? 'View Less' : 'View More'}

--- a/frontend/src/pages/assessment/results/page.tsx
+++ b/frontend/src/pages/assessment/results/page.tsx
@@ -194,7 +194,7 @@ export default function ResultsPage() {
   const [symptoms, setSymptoms] = useState<string[]>([]);
   const [expandableSymptoms, setExpandableSymptoms] = useState(false);
   const [isClamped, setIsClamped] = useState(false);
-  const ref = useRef(null);
+  const ref = useRef<HTMLParagraphElement>(null);
 
   // Helper function to normalize string values for more reliable comparisons
   const normalizeValue = (value: string | null): string => {

--- a/frontend/src/pages/assessment/results/page.tsx
+++ b/frontend/src/pages/assessment/results/page.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/src/components/ui/!to-migrate/button';
 import { Card, CardContent } from '@/src/components/ui/!to-migrate/card';
 import { MessageCircle, Save, Share2, Download } from 'lucide-react';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { ChatModal } from '@/src/pages/chat/page';
 import { FullscreenChat } from '@/src/pages/chat/FullScreenChat';
 import { toast } from 'sonner';
@@ -192,6 +192,9 @@ export default function ResultsPage() {
   const [flowLevel, setFlowLevel] = useState<string>('');
   const [painLevel, setPainLevel] = useState<string>('');
   const [symptoms, setSymptoms] = useState<string[]>([]);
+  const [expandableSymptoms, setExpandableSymptoms] = useState(false);
+  const [isClamped, setIsClamped] = useState(false);
+  const ref = useRef(null);
 
   // Helper function to normalize string values for more reliable comparisons
   const normalizeValue = (value: string | null): string => {
@@ -447,6 +450,13 @@ export default function ResultsPage() {
     }
   };
 
+  useEffect(() => {
+    if (ref.current) {
+      const maxHeight = parseFloat(getComputedStyle(ref.current).lineHeight)* 2;
+      setIsClamped(ref.current.scrollHeight > maxHeight);
+    }
+  }, [symptoms]);
+
   return (
     <div className="flex min-h-screen flex-col">
       <main className="mx-auto w-full max-w-4xl flex-1 p-6">
@@ -477,7 +487,7 @@ export default function ResultsPage() {
               </p>
             </div>
 
-            <div className="mb-8 grid grid-cols-1 gap-6 dark:text-gray-900 md:grid-cols-2">
+            <div className="mb-8 grid grid-cols-1 gap-6 dark:text-gray-900 md:grid-cols-2 items-start">
               <div className="flex items-center gap-3 rounded-xl bg-gray-50 p-4">
                 <div>
                   <img src="/resultAssets/time.svg" className="h-[55px] w-[55px]" alt="time-icon" />
@@ -545,9 +555,19 @@ export default function ResultsPage() {
                 </div>
                 <div className="flex-1 overflow-x-auto">
                   <h3 className="mb-2 text-lg font-medium">Symptoms</h3>
-                  <p className="whitespace-normal break-words text-gray-600">
+                  <p title={symptoms.length > 0 ? symptoms.join(', ') : 'None reported'} ref={ref} className={`whitespace-normal break-words text-gray-600 ${expandableSymptoms ? '' : 'line-clamp-2'} whitespace-pre-line`}>
                     {symptoms.length > 0 ? symptoms.join(', ') : 'None reported'}
                   </p>
+
+                  {isClamped ? 
+                    <button
+                    onClick={() => setExpandableSymptoms((prev) => !prev)}
+                    className="text-sm text-pink-600 hover:text-pink-700"
+                    aria-expanded={expandableSymptoms}   
+                    aria-controls="symptoms-content"
+                  >
+                    {expandableSymptoms ? 'View Less' : 'View More'}
+                  </button> : ''}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Please provide a clear and concise description of the changes made in this PR.

- Added View More and View Less functionality for symptoms card in assessment results page
- Added tooltip for the symptons card
- Adjusted the card height based on the card details
- Added aria enchancements to the symptom cards

## Screenshots / Screen Recordings

https://drive.google.com/file/d/1Hoa7Hdrfd8UqgLvE_rrhgsqREWiQPYaI/view?usp=sharing

![Screenshot (560)](https://github.com/user-attachments/assets/f8dc5700-db0d-4537-a8b7-2399aedbcf37)
![Screenshot (561)](https://github.com/user-attachments/assets/641123cf-3a5b-4473-aa4e-525f1d4edd64)

## Checklist
- [X] Pulled the latest `main` branch and resolved any merge conflicts
- [X] Ran `cd frontend && npm run build` to confirm no type or build errors
- [ ] Ran linter/formatter commands (e.g., `npm run lint`) and fixed warnings/errors
- [X] Manually tested the feature/fix on relevant browsers/devices (if UI-related)
- [ ] Added or updated relevant documentation (if applicable)
- [X] Linked related issue(s) correctly in the PR description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue)
- [X] Added Screenshots to the PR where applicable. Screenshots are mandatory for any frontend, styling, or layout changes.

## Issue Links
Closes #325 