### PR TITLE
fix(navigation): prevent hard refresh in navbar links by refactoring navigation logic

### DIFF
--- a/frontend/src/components/navbar/Header.tsx
+++ b/frontend/src/components/navbar/Header.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Button } from '@/src/components/buttons/button';
 import { useIsMobile } from '@/src/hooks/use-mobile';
 import UserIcon from '@/src/components/navbar/UserIcon';
 import ThemeToggle from '@/src/components/theme/ThemeToggle';
+import { useQuickNavigate } from '@/src/hooks/useQuickNavigate';
 
 interface HeaderProps {
   logoSrc?: string;
@@ -19,7 +20,7 @@ const Header = ({
 }: HeaderProps) => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const isMobile = useIsMobile();
-  const navigate = useNavigate();
+  const { quickNavigate } = useQuickNavigate();
 
   const toggleMobileMenu = () => {
     setMobileMenuOpen(!mobileMenuOpen);
@@ -28,8 +29,7 @@ const Header = ({
   const handleLogoClick = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    console.log('🚀 Using window.location.href to navigate to: /');
-    window.location.href = '/';
+    quickNavigate('/');
   };
 
   return (

--- a/frontend/src/components/navbar/UserIcon.tsx
+++ b/frontend/src/components/navbar/UserIcon.tsx
@@ -1,16 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import { User, List, MessageCircle } from 'lucide-react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { assessmentApi } from '@/src/pages/assessment/api';
 import { getConversationsList } from '@/src/pages/chat/sidebar/api/get-list/getConversationsList';
 import { useAuth } from '@/src/pages/auth/context/useAuthContext';
+import { useQuickNavigate } from '@/src/hooks/useQuickNavigate';
 
 const UserIcon: React.FC = () => {
   const { isAuthenticated } = useAuth();
   const [hasHistory, setHasHistory] = useState(false);
   const [hasConversations, setHasConversations] = useState(false);
   const [loading, setLoading] = useState(true);
-  const navigate = useNavigate();
+  const { quickNavigate } = useQuickNavigate();
 
   useEffect(() => {
     const checkHistory = async () => {
@@ -39,22 +40,19 @@ const UserIcon: React.FC = () => {
   const handleProfileClick = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    console.log('🚀 Using window.location.href to navigate to: /user/profile');
-    window.location.href = '/user/profile';
+    quickNavigate('/user/profile');
   };
 
   const handleHistoryClick = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    console.log('🚀 Using window.location.href to navigate to: /assessment/history');
-    window.location.href = '/assessment/history';
+    quickNavigate('/assessment/history');
   };
 
   const handleChatClick = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    console.log('🚀 Using window.location.href to navigate to: /chat');
-    window.location.href = '/chat';
+    quickNavigate('/chat');
   };
 
   if (!isAuthenticated) {
@@ -85,11 +83,7 @@ const UserIcon: React.FC = () => {
           <List className="h-5 w-5" />
         </button>
       )}
-      <button 
-        onClick={handleProfileClick}
-        title="Profile" 
-        className="hover:text-pink-600"
-      >
+      <button onClick={handleProfileClick} title="Profile" className="hover:text-pink-600">
         <User className="h-5 w-5" />
       </button>
     </div>

--- a/frontend/src/pages/assessment/list/page.tsx
+++ b/frontend/src/pages/assessment/list/page.tsx
@@ -1,15 +1,16 @@
 import { useEffect, useState } from 'react';
 import { format, isValid, parseISO } from 'date-fns';
 import { Calendar, ChevronRight } from 'lucide-react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { assessmentApi, type Assessment } from '@/src/pages/assessment/api';
 import { toast } from 'sonner';
 import PageTransition from '../animations/page-transitions';
+import { useQuickNavigate } from '@/src/hooks/useQuickNavigate';
 
 export default function HistoryPage() {
   // #actual
   const [assessments, setAssessments] = useState<Assessment[]>([]);
-  const navigate = useNavigate();
+  const { quickNavigate } = useQuickNavigate();
 
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -121,7 +122,7 @@ export default function HistoryPage() {
               <div className="mt-6">
                 <button
                   onClick={() => {
-                    navigate('/assessment');
+                    quickNavigate('/assessment');
                   }}
                   className="inline-flex items-center rounded-lg bg-pink-600 px-4 py-2 text-white transition-colors hover:bg-pink-700"
                 >


### PR DESCRIPTION
This PR fixes the hard refresh issue that occurred when navigating from the chat page using navbar links. The original implementation using `useNavigate` was causing full page reloads instead of smooth client-side transitions.

## Checklist
Before submitting this PR, the following **must** be confirmed:

- [x] Pulled the latest `main` branch and resolved any merge conflicts
- [x] Ran `cd frontend && npm run build` to confirm no type or build errors
- [x] Ran linter/formatter commands (e.g., `npm run lint`) and fixed warnings/errors
- [x] Manually tested the feature/fix on relevant browsers/devices (if UI-related)
- [x] Added or updated relevant documentation (if applicable)
- [x] Linked related issue(s) correctly in the PR description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue)
- [x] Added Screenshots to the PR where applicable. Screenshots are mandatory for any frontend, styling, or layout changes.

## Issue Links
Closes #333 