### PR TITLE
Append LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -10,7 +10,7 @@ This work is licensed under a [Creative Commons Attribution-NonCommercial-NoDeri
 [cc-by-nc-nd-image]: https://licensebuttons.net/l/by-nc-nd/4.0/88x31.png
 [cc-by-nc-nd-shield]: https://img.shields.io/badge/License-CC%20BY--NC--ND%204.0-lightgrey.svg
 
-# Caveat number 1 08/6/25 -- Contributors may remix and redistribute the software
+# Caveat number 1 08/6/25 -- Contributors may remix and redistribute code snippets
 
 Code Contributors may remix and redistribute the software under the following liscence.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,5 @@
+# dafault license
+
 [![CC BY-NC-ND 4.0][cc-by-nc-nd-image]][cc-by-nc-nd]
 
 [![CC BY-NC-ND 4.0][cc-by-nc-nd-shield]][cc-by-nc-nd]
@@ -7,3 +9,49 @@ This work is licensed under a [Creative Commons Attribution-NonCommercial-NoDeri
 [cc-by-nc-nd]: http://creativecommons.org/licenses/by-nc-nd/4.0/
 [cc-by-nc-nd-image]: https://licensebuttons.net/l/by-nc-nd/4.0/88x31.png
 [cc-by-nc-nd-shield]: https://img.shields.io/badge/License-CC%20BY--NC--ND%204.0-lightgrey.svg
+
+# Caveat number 1 08/6/25 -- Contributors may remix and redistribute the software
+
+Code Contributors may remix and redistribute the software under the following liscence.
+
+```txt
+This is free and unencumbered software released into the public domain.
+
+Contributors are free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>
+```
+
+## Reasons for this Caveat
+
+- the primary focus of this app is outreach and educational experience for software developers
+- the app is a concept app, it will not be commercialised nor is it intended/liable for earnest medical use.
+- considering the absence of financial or real product incentive, providing an unlicence provides opportunity for all code contributors to use this codebase as a highly valuable educational experience. Just as an example, if they solve backend encryption problems, laer in their software careers they can use the code for other projects
+
+# Caveat number 2 08/6/25 -- Design Concept is strictly copyrighted
+
+The license refers only to the *functionality* of the software, e.g. architecture, methods, technology stack.
+
+The Design of "Dottie" is strictly copyrighted. It was kindly permitted from a third party.
+
+# license history
+- the licence was formerly [Creative Commons Attribution 4.0 International License][cc-by] with restrictions around remixing and distribution and was proposed to be changed on 08/06/25

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -52,6 +52,3 @@ For more information, please refer to <https://unlicense.org>
 The license refers only to the *functionality* of the software, e.g. architecture, methods, technology stack.
 
 The Design of "Dottie" is strictly copyrighted. It was kindly permitted from a third party.
-
-# license history
-- the licence was formerly [Creative Commons Attribution 4.0 International License][cc-by] with restrictions around remixing and distribution and was proposed to be changed on 08/06/25

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-# dafault license
+# default license
 
 [![CC BY-NC-ND 4.0][cc-by-nc-nd-image]][cc-by-nc-nd]
 
@@ -40,6 +40,10 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to <https://unlicense.org>
 ```
+
+## definition of "Contributor"
+
+- a contributor can be defined as someone who has made 3 or more pull requests to this project
 
 ## Reasons for this Caveat
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-# default license
+# Default license
 
 [![CC BY-NC-ND 4.0][cc-by-nc-nd-image]][cc-by-nc-nd]
 
@@ -10,9 +10,9 @@ This work is licensed under a [Creative Commons Attribution-NonCommercial-NoDeri
 [cc-by-nc-nd-image]: https://licensebuttons.net/l/by-nc-nd/4.0/88x31.png
 [cc-by-nc-nd-shield]: https://img.shields.io/badge/License-CC%20BY--NC--ND%204.0-lightgrey.svg
 
-# Caveat number 1 08/6/25 -- Contributors may remix and redistribute code snippets
+# Caveat number 1 08/6/25 -- Contributors may remix and redistribute code snippets that they have contributed
 
-Code Contributors may remix and redistribute the software under the following liscence.
+Code Contributors may remix and redistribute code snippets under the following liscence, providing they have written the code themselves. This does not include code written by others.
 
 ```txt
 This is free and unencumbered software released into the public domain.


### PR DESCRIPTION
# problem statement

Under the current license contributors are not able to reuse ***their own*** code for other projects.

# Notes

Caveat #1 essentially allows contributors to reuse and redistribute code that they have authored in this project. Equally it protects IP theft from contributor to contributor.

- There should be as many non-financial incentives for this project as possible
- the risks associated with this project in general are significantly small as there is no commercial harm that can be done
- using a restrictive license for this project could do more harm than good as it would prevent contributors from reusing their own code a lot of the time. There should be as many non-financial incentives for this project as possible
- the worst edge-case is that a contributor "commercialises" this code in an external project, this would not really de-value the project in any way it's already limited to a concept app. I would argue that this would be a "good problem" as would require significant attention, popularity and reach for someone to get this far.
- contributors can "ringfence" sections of the code in `LICENSE.md` if necessary

Caveat #2 clarifies that the design is strictly copyrighted as it was donated generously from a third party
