### PR TITLE
Replace window.confirm with custom dialog in DeleteAccountButton

### DIFF
--- a/frontend/src/pages/user/profile/delete-account/DeleteAccountButton.tsx
+++ b/frontend/src/pages/user/profile/delete-account/DeleteAccountButton.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { useAuth } from '@/src/pages/auth/context/useAuthContext';
 import { deleteUserAccount } from './api';
+import DeleteConfirmationDialog from './DeleteConfirmationDialog';
 
 interface DeleteAccountButtonProps {
   className?: string;
@@ -13,19 +14,13 @@ export const DeleteAccountButton: React.FC<DeleteAccountButtonProps> = ({
   className = '',
   variant = 'danger'
 }) => {
+  const [isDialogOpen, setDialogOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
   const { user, logout } = useAuth();
 
   const handleDeleteAccount = async () => {
     if (isLoading) return;
-
-    const confirmDelete = window.confirm(
-      'Are you sure you want to delete your account? This action cannot be undone.'
-    );
-
-    if (!confirmDelete) return;
-
     setIsLoading(true);
 
     try {
@@ -40,6 +35,7 @@ export const DeleteAccountButton: React.FC<DeleteAccountButtonProps> = ({
       toast.error('Failed to delete account');
     } finally {
       setIsLoading(false);
+      setDialogOpen(false);
     }
   };
 
@@ -51,14 +47,23 @@ export const DeleteAccountButton: React.FC<DeleteAccountButtonProps> = ({
   };
 
   return (
-    <button
-      type="button"
-      onClick={handleDeleteAccount}
-      disabled={isLoading}
-      className={`${baseClasses} ${variantClasses[variant]} ${className}`}
-    >
-      {isLoading ? 'Deleting...' : 'Delete Account'}
-    </button>
+    <>
+      <button
+        type="button"
+        onClick={() => setDialogOpen(true)}
+        className={`${baseClasses} ${variantClasses[variant]} ${className}`}
+        disabled={isLoading}
+      >
+        Delete Account
+      </button>
+
+      <DeleteConfirmationDialog
+        isOpen={isDialogOpen}
+        onCancel={() => setDialogOpen(false)}
+        onConfirm={handleDeleteAccount}
+        isLoading={isLoading}
+      />
+    </>
   );
 };
 

--- a/frontend/src/pages/user/profile/delete-account/DeleteConfirmationDialog.tsx
+++ b/frontend/src/pages/user/profile/delete-account/DeleteConfirmationDialog.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/src/components/ui/dialog.tsx';
+import { DeleteConfirmationDialogProps } from './types';
+import { useTheme } from '@/src/context/theme/useTheme.ts';
+
+const DeleteConfirmationDialog: React.FC<DeleteConfirmationDialogProps> = ({
+  isOpen,
+  onConfirm,
+  onCancel,
+  isLoading
+}) => {
+  const { isDarkMode } = useTheme();
+  const bgColor = isDarkMode
+    ? 'bg-black-100 text-white border-white/10'
+    : 'bg-white text-black border-gray-200';
+  return (
+    <Dialog open={isOpen} onOpenChange={onCancel}>
+      <DialogContent
+        className={`${bgColor} max-w-md rounded-xl border border-border p-8 shadow-lg backdrop-blur-lg`}
+      >
+        <DialogHeader>
+          <DialogTitle>Confirm Account Deletion</DialogTitle>
+        </DialogHeader>
+        <p>Are you sure you want to delete your account?This action cannot be undone. </p>
+        <div className="mt-4 flex justify-end gap-4">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded border px-4 py-2 text-sm font-medium hover:bg-gray-500"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isLoading}
+            className="rounded bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
+          >
+            {isLoading ? 'Deleting...' : 'Confirm'}
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default DeleteConfirmationDialog;


### PR DESCRIPTION
This PR addresses the issue where the DeleteAccountButton in frontend/src/pages/user/profile/delete-account/DeleteAccountButton.tsx uses the native window.confirm() for account deletion confirmation. It replaces that with a custom modal built using the existing design system components (Dialog, DialogContent, etc.).

## Screenshots / Screen Recordings
### Dark<img width="1337" alt="Screenshot 2025-06-21 at 2 38 31 PM" src="https://github.com/user-attachments/assets/576d7b64-e1ce-4c1d-9770-ba4cb110332c" />
### Account Deleted Successfully  <img width="1430" alt="Screenshot 2025-06-21 at 2 47 45 PM" src="https://github.com/user-attachments/assets/445b85d1-57c2-4ab6-9ce3-cbcc30acce5d" />

### Light<img width="1352" alt="Screenshot 2025-06-21 at 2 38 19 PM" src="https://github.com/user-attachments/assets/43af4f2e-f413-452d-9f7b-dd79840844c5" />



## ✅ Changes Made

1. Removed window.confirm() from DeleteAccountButton.tsx
2. Created a reusable DeleteConfirmationDialog
3. Dialog, DialogHeader, DialogTitle, DialogContent
4. Used DeleteConfirmationDialogProps for typed props
5. Managed open/close state with useState
6. Styled the modal with dark/light mode support via ThemeContext


## Checklist

- [x] Pulled the latest `main` branch and resolved any merge conflicts
- [x] Ran `cd frontend && npm run build` to confirm no type or build errors
- [x] Ran linter/formatter commands (e.g., `npm run lint`) and fixed warnings/errors
- [x] Manually tested the feature/fix on relevant browsers/devices (if UI-related)
- [x] Added or updated relevant documentation (if applicable)
- [x] Linked related issue(s) correctly in the PR description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue)
- [x] Added Screenshots to the PR where applicable. Screenshots are mandatory for any frontend, styling, or layout changes.

## 🔗 Issue Links
Closes #371
